### PR TITLE
Fixed problem with strings not being printed on LCD display (only fir…

### DIFF
--- a/src/IicLcd.cpp
+++ b/src/IicLcd.cpp
@@ -275,7 +275,7 @@ inline size_t IIClcd::write(uint8_t value) {
 	if (!_bufferOnly) {
 		send(value, Rs);
 	}
-	return 0;
+	return 1;  
 }
 
 /************ low level data pushing commands **********/


### PR DESCRIPTION
…st char printed). Caused by fix in library,

Check Print::write(byte) return and stop on fail (#4527)